### PR TITLE
Update to CI scripts use new images

### DIFF
--- a/.github/workflows/ci-conan-gcc.yml
+++ b/.github/workflows/ci-conan-gcc.yml
@@ -8,38 +8,54 @@ env:
   CONAN_PASSWORD_SINTEF: ${{ secrets.CONAN_PASSWORD }}
   CONAN_LOGIN_USERNAME_SINTEF: ${{ secrets.CONAN_USER }}
   CONFIG_URL: https://github.com/sintef-ocean/conan-configs.git
+  DEBIAN_FRONTEND: noninteractive
+  TZ: Etc/UTC
 
 jobs:
   conan-with-gcc:
     name: Conan
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
         profile: [gcc]
-        compiler_version: [10, 11, 12, 13]
+        compiler_version: [11, 12, 13, 14]
         channel: ["${{ github.ref_type == 'tag' && 'stable' || 'testing' }}"]
+        include:
+          - linux: debian:latest
+          -
+            linux: debian:trixie
+            compiler_version: 14
+          -
+            linux: ubuntu:24.04
+            compiler_version: 13
+          -
+            linux: debian:bookworm
+            compiler_version: 12
+          -
+            linux: ubuntu:22.04
+            compiler_version: 11
     container:
-      image: conanio/gcc${{ matrix.compiler_version }}-ubuntu16.04
+      image: ${{ matrix.linux }}
       options: -u 0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install prerequisites
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-          pip3 install --upgrade setuptools pip
-          pip3 install --upgrade conan~=2.0
-      - name: Configure Conan and package name
+          apt-get update
+          apt-get install -y jq pipx build-essential cmake git
+          pipx install conan
+          echo "/github/home/.local/bin" >> $GITHUB_PATH
+      - name: Conan configs
         run: |
           conan remote add sintef ${{ env.CONAN_UPLOAD }}
           echo "pkg_name=$(conan inspect -f json . | jq .name -r)" >> $GITHUB_ENV
-      - name: Conan create
-        run: |
           git config --global --add safe.directory '*'
           conan config install ${{ env.CONFIG_URL }}  --type git -sf conan2.0
           conan config install ${{ env.CONFIG_URL }}  --type git -sf profiles -tf profiles
+      - name: Conan create
+        run: |
           conan create -s build_type=${{ matrix.build_type }} \
             -s compiler.version=${{ matrix.compiler_version }} \
             -pr:b=${{ matrix.profile }} -pr:h=${{ matrix.profile }} \

--- a/.github/workflows/ci-conan-msvc.yml
+++ b/.github/workflows/ci-conan-msvc.yml
@@ -12,13 +12,13 @@ env:
 jobs:
   conan-with-msvc:
     name: Conan
-    runs-on: windows-2022
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
         profile: [msvc17]
-        compiler_version: [192, 193]
+        compiler_version: [192, 194]
         channel: ["${{ github.ref_type == 'tag' && 'stable' || 'testing' }}"]
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -56,10 +56,9 @@ for CPPFMU that you can use in your code, but you still need to compile
 `fmi_functions.cpp`. The package can be created with `conan create . --user sintef
 --channel stable`. The recipe and some precompiled binaries are available on Sintef
 Ocean's public artifactory], which can be added with `conan remote add sintef-public
-https://artifactory.smd.sintef.no/artifactory/api/conan/conan-local`. Note that when using
-the conan recipe, FMI 1 or 2 is added as a dependency, so you do not need to fetch them
-yourself. To use CPPFMU with conan, add the following lines to your `conanfile.py` and
-`CMakeLists.txt`:
+https://package.smd.sintef.no`. Note that when using the conan recipe, FMI 1 or 2 is added
+as a dependency, so you do not need to fetch them yourself. To use CPPFMU with conan, add
+the following lines to your `conanfile.py` and `CMakeLists.txt`:
 
 `conanfile.py`:
 ```python

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from os import path
+from os import path, environ
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
@@ -44,7 +44,12 @@ class CppFmuConan(ConanFile):
     def export(self):
         copy(self, "version.txt", self.recipe_folder, self.export_folder)
         git = Git(self, self.recipe_folder)
-        scm_url, scm_commit = git.get_url_and_commit()
+        if environ.get("CI") == "true":
+            scm_commit = environ.get("GITHUB_SHA")
+            scm_url = f"{environ.get('GITHUB_SERVER_URL')}/{environ.get('GITHUB_REPOSITORY')}"
+        else:
+            scm_url, scm_commit = git.get_url_and_commit()
+
         update_conandata(self, {"sources": {"commit": scm_commit, "url": scm_url}})
 
     def set_version(self):


### PR DESCRIPTION
- This work updates workflow actions to use Debian and Ubuntu container images for gcc 11, 12, 13, 14, where the gcc version used matches the distro's default gcc version;
- The readme is updated to use the new sintef conan remote, which is https://package.smd.sintef.no;
- For MSVC toolsets 192 and 194 are built, since 193 is not available in github actions;
- Also, a minor change to the conan recipe is added to ensure that the git URL in conandata.yml is https://github.com/viproma/cppfmu.